### PR TITLE
Modify state machine decoder to include memory networks

### DIFF
--- a/modules/memory_decoder_attn.py
+++ b/modules/memory_decoder_attn.py
@@ -1,0 +1,48 @@
+import torch
+from allennlp import nn
+from allennlp.modules import Attention
+from torch.nn import Parameter as Param
+from allennlp.nn import util
+
+class MemDecoderAttn(torch.nn.Module):
+    def __init__(self,
+                 attention: Attention,
+                 embedding_dim,
+                 nhop):
+        #
+        # Input
+        #  embedding_dim : number of embedding dimentions in memory
+        #  nhop: number of memory hops
+        #
+        super(MemDecoderAttn, self).__init__()
+
+        self.attention = attention
+        self.nhop = nhop
+        self.hidden = nn.Linear(embedding_dim * 2, embedding_dim)
+
+    def forward(self,
+                Q: torch.Tensor,
+                K: torch.Tensor,
+                V: torch.Tensor):
+        #
+        # Input
+        #  Q : Matrix of queries: (batch_size, num_question_toks, embedding_dim)
+        #  K : Matrix of keys: (batch_size, num_memories, embedding_dim)
+        #  V : Matrix of values: (batch_size, num_memories, embedding_dim)
+        #
+        # Output
+        #  R : soft-retrieval of values: (batch_size, num_question_toks, embedding_dim)
+        #  attn_weights : soft-retrieval of values: (batch_size, num_question_toks, num_memories)
+        Q_hop = Q
+        for h in range(self.nhop):
+            attn_weights = self.attention(Q_hop, K, None)
+            attn_weights = torch.nn.functional.softmax(attn_weights, dim=2)
+            R = util.weighted_sum(V, attn_weights)
+            concat_by_step = torch.cat((Q_hop, R), 1)
+            # (batch_size, num_question_toks, embedding_dim)
+            Q_hop = self.tanh(self.hidden(concat_by_step))
+
+        return Q_hop, attn_weights
+
+
+

--- a/semparse/contexts/sql_grammar.py
+++ b/semparse/contexts/sql_grammar.py
@@ -75,7 +75,7 @@ GRAMMAR_DICTIONARY["ordering"] = ['(ws "asc")', '(ws "desc")']
 GRAMMAR_DICTIONARY["col_ref"] = ['(table_name ws "." ws column_name)', 'column_name']
 GRAMMAR_DICTIONARY["table_source"] = ['(table_name ws "as" ws table_alias)', 'table_name']
 GRAMMAR_DICTIONARY["table_name"] = ["table_alias"]
-GRAMMAR_DICTIONARY["table_alias"] = ['"t1"', '"t2"', '"t3"', '"t4"']
+GRAMMAR_DICTIONARY["table_alias"] = ['"t1"', '"t2"', '"t3"', '"t4"', '"t5"', '"t6"']
 GRAMMAR_DICTIONARY["column_name"] = []
 
 GRAMMAR_DICTIONARY["ws"] = ['~"\s*"i']

--- a/semparse/worlds/spider_world.py
+++ b/semparse/worlds/spider_world.py
@@ -6,8 +6,7 @@ from parsimonious.exceptions import ParseError
 
 from semparse.contexts.spider_context_utils import format_grammar_string, initialize_valid_actions, SqlVisitor
 from semparse.contexts.spider_db_context import SpiderDBContext
-from semparse.contexts.spider_nl_context import SpiderNLContext
-from semparse.contexts.spider_db_grammar import GRAMMAR_DICTIONARY, update_grammar_with_tables, \
+from semparse.contexts.sql_grammar import GRAMMAR_DICTIONARY, update_grammar_with_tables, \
     update_grammar_to_be_table_names_free, update_grammar_flip_joins
 
 
@@ -16,7 +15,7 @@ class SpiderWorld:
     World representation for spider dataset.
     """
 
-    def __init__(self, db_context: SpiderDBContext, nl_context: SpiderNLContext, query: Optional[List[str]], allow_alias: bool = False) -> None:
+    def __init__(self, db_context: SpiderDBContext, query: Optional[List[str]], allow_alias: bool = False) -> None:
         self.db_id = db_context.db_id
         self.allow_alias = allow_alias
 
@@ -57,7 +56,6 @@ class SpiderWorld:
 
         self.query = remove_from_clause(query)
         self.db_context = db_context
-        self.nl_context = nl_context
 
         # keep a list of entities names as they are given in sql queries
         self.entities_names = {}

--- a/state_machines/states/rnn_statelet.py
+++ b/state_machines/states/rnn_statelet.py
@@ -52,7 +52,10 @@ class RnnStatelet:
                  attended_input: torch.Tensor,
                  encoder_outputs: List[torch.Tensor],
                  encoder_output_mask: List[torch.Tensor],
-                 decoder_outputs: Optional[torch.Tensor] = None) -> None:
+                 decoding_step: int = 0,
+                 decoder_outputs: Optional[torch.Tensor] = None,
+                 decoder_input_action_embeddings: Optional[torch.Tensor] = None,
+                 decoder_output_action_embeddings: Optional[torch.Tensor] = None,) -> None:
         self.hidden_state = hidden_state
         self.memory_cell = memory_cell
         self.previous_action_embedding = previous_action_embedding
@@ -60,6 +63,9 @@ class RnnStatelet:
         self.encoder_outputs = encoder_outputs
         self.encoder_output_mask = encoder_output_mask
         self.decoder_outputs = decoder_outputs
+        self.decoding_step = decoding_step
+        self.decoder_action_input_embeddings = decoder_input_action_embeddings
+        self.decoder_action_output_embeddings = decoder_output_action_embeddings
 
     def __eq__(self, other):
         if isinstance(self, other.__class__):

--- a/train_configs/defaults.jsonnet
+++ b/train_configs/defaults.jsonnet
@@ -1,0 +1,93 @@
+local dataset_path = "dataset/";
+
+{
+  "random_seed": 5,
+  "numpy_seed": 5,
+  "pytorch_seed": 5,
+  "dataset_reader": {
+    "type": "base",
+    "tables_file": dataset_path + "tables.json",
+    "dataset_path": dataset_path + "database",
+    "lazy": false,
+    "keep_if_unparsable": false,
+    "loading_limit": -1
+  },
+  "validation_dataset_reader": {
+    "type": "spider",
+    "tables_file": dataset_path + "tables.json",
+    "dataset_path": dataset_path + "database",
+    "lazy": false,
+    "keep_if_unparsable": true,
+    "loading_limit": -1
+  },
+  "train_data_path": dataset_path + "train_spider_star.json",
+  "validation_data_path": dataset_path + "dev_star.json",
+  "model": {
+    "type": "MMParser",
+    "dataset_path": dataset_path,
+    "parse_sql_on_decoding": true,
+    "decoder_self_attend": true,
+    "input_memory_embedder": {
+      "tokens": {
+        "type": "embedding",
+        "embedding_dim": 100,
+        "trainable": true
+      }
+    },
+    "output_memory_embedder": {
+      "tokens": {
+        "type": "embedding",
+        "embedding_dim": 100,
+        "trainable": true
+      }
+    },
+    "action_embedding_dim": 200,
+    "question_encoder": {
+      "type": "lstm",
+      "input_size": 400,
+      "hidden_size": 400,
+      "bidirectional": true,
+      "num_layers": 1
+    },
+    "input_memory_encoder": {
+      "type": "boe",
+      "embedding_dim": 100,
+      "averaged": true
+    },
+    "output_memory_encoder": {
+      "type": "boe",
+      "embedding_dim": 100,
+      "averaged": true
+    },
+    "decoder_beam_search": {
+      "beam_size": 10
+    },
+    "nhop": 6,
+    "decoding_nhop": 1,
+    "training_beam_size": 1,
+    "max_decoding_steps": 100,
+    "input_attention": {"type": "dot_product"},
+    "past_attention": {"type": "dot_product"},
+    "dropout": 0.5
+  },
+  "iterator": {
+    "type": "basic",
+    "batch_size" : 15
+  },
+  "validation_iterator": {
+    "type": "basic",
+    "batch_size" : 1
+  },
+  "trainer": {
+    "num_epochs": 100,
+    "cuda_device": 0,
+    "patience": 20,
+    "validation_metric": "+sql_match",
+    "optimizer": {
+      "type": "adam",
+      "lr": 0.001,
+      "weight_decay": 5e-4
+    },
+    "num_serialized_models_to_keep": 2
+  }
+}


### PR DESCRIPTION
	new file:   modules/memory_decoder_attn.py
	modified:   semparse/contexts/sql_grammar.py
	modified:   semparse/worlds/spider_world.py
	modified:   state_machines/states/rnn_statelet.py
	modified:   state_machines/transition_functions/attend_past_schema_items_transition.py
	new file:   train_configs/defaults.jsonnet